### PR TITLE
Persist theme preference using cookies

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import "./globals.css";
 import { Nunito, Titillium_Web } from 'next/font/google'
 
 import { Providers } from "@/providers";
+import { cookies } from "next/headers";
 
 import { SpeedInsights } from "@vercel/speed-insights/next"
 import { GoogleAnalytics } from "@/components/shared";
@@ -50,11 +51,15 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  
+
+  const cookieStore = cookies();
+  const themeCookie = cookieStore.get("theme")?.value;
+  const initialTheme = themeCookie === "light" || themeCookie === "dark" ? themeCookie : undefined;
+
   return (
-    <html lang="en" suppressHydrationWarning>
+    <html lang="en" className={initialTheme === "dark" ? "dark" : ""} suppressHydrationWarning>
       <body className={`${nunito.className} ${titilum.className} antialiased`}>
-        <Providers>
+        <Providers initialTheme={initialTheme}>
           {children}
           <SpeedInsights />
         </Providers>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,19 +12,28 @@ import { FaLinkedinIn } from "react-icons/fa";
 
 export default function Page() {
   const [isContactOpen, setIsContactOpen] = React.useState<boolean>(false);
-  const { theme, setTheme } = useTheme();
+  const { theme, setTheme, resolvedTheme } = useTheme();
 
   React.useEffect(() => {
-    setTheme('dark');
-  }, []);
+    const activeTheme = theme === 'system' ? resolvedTheme : theme;
+
+    if (!activeTheme) {
+      return;
+    }
+
+    document.cookie = `theme=${activeTheme}; path=/; max-age=${60 * 60 * 24 * 365}`;
+  }, [theme, resolvedTheme]);
 
   const handleTheme = () => {
-    if (theme === 'light') {
+    const currentTheme = theme === 'system' ? resolvedTheme : theme;
+
+    if (currentTheme === 'light') {
       setTheme('dark');
-      return
+      return;
     }
+
     setTheme('light');
-  }
+  };
 
   // const [isClient, setIsClient] = React.useState(false);
   

--- a/src/providers/Providers.tsx
+++ b/src/providers/Providers.tsx
@@ -8,7 +8,11 @@ import { TooltipProvider } from "@/components/ui/tooltip"
 import { ThemeProvider } from "./theme-provider";
 import { Toaster } from "@/components/ui/toaster";
 
-export const Providers = ({children}: PropsWithChildren) => {
+type ProvidersProps = PropsWithChildren<{
+  initialTheme?: 'light' | 'dark';
+}>;
+
+export const Providers = ({ children, initialTheme }: ProvidersProps) => {
   // Create a client
   const queryClient = new QueryClient({
     defaultOptions: {
@@ -24,9 +28,10 @@ export const Providers = ({children}: PropsWithChildren) => {
       <TooltipProvider>   
         <ThemeProvider
           attribute="class"
-          defaultTheme="system"
+          defaultTheme={initialTheme ?? "dark"}
           enableSystem
           disableTransitionOnChange
+          storageKey="theme"
         >
           {children}
           <Toaster />


### PR DESCRIPTION
## Summary
- read the persisted theme from a cookie on the server and pass it into the app providers
- sync the active theme to a long-lived cookie whenever the user toggles the theme
- ensure the theme provider keeps using the same storage key so cookie and client stay in sync

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e18bcd580883328df63796ccec509b