### PR TITLE
Fix theme cookie retrieval in layout

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import "./globals.css";
 import { Nunito, Titillium_Web } from 'next/font/google'
 
 import { Providers } from "@/providers";
+import { cookies } from "next/headers";
 
 import { SpeedInsights } from "@vercel/speed-insights/next"
 import { GoogleAnalytics } from "@/components/shared";
@@ -45,16 +46,20 @@ export const metadata: Metadata = {
   },
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  
+
+  const cookieStore = await cookies();
+  const themeCookie = cookieStore.get("theme")?.value;
+  const initialTheme = themeCookie === "light" || themeCookie === "dark" ? themeCookie : undefined;
+
   return (
-    <html lang="en" suppressHydrationWarning>
+    <html lang="en" className={initialTheme === "dark" ? "dark" : ""} suppressHydrationWarning>
       <body className={`${nunito.className} ${titilum.className} antialiased`}>
-        <Providers>
+        <Providers initialTheme={initialTheme}>
           {children}
           <SpeedInsights />
         </Providers>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,19 +12,28 @@ import { FaLinkedinIn } from "react-icons/fa";
 
 export default function Page() {
   const [isContactOpen, setIsContactOpen] = React.useState<boolean>(false);
-  const { theme, setTheme } = useTheme();
+  const { theme, setTheme, resolvedTheme } = useTheme();
 
   React.useEffect(() => {
-    setTheme('dark');
-  }, []);
+    const activeTheme = theme === 'system' ? resolvedTheme : theme;
+
+    if (!activeTheme) {
+      return;
+    }
+
+    document.cookie = `theme=${activeTheme}; path=/; max-age=${60 * 60 * 24 * 365}`;
+  }, [theme, resolvedTheme]);
 
   const handleTheme = () => {
-    if (theme === 'light') {
+    const currentTheme = theme === 'system' ? resolvedTheme : theme;
+
+    if (currentTheme === 'light') {
       setTheme('dark');
-      return
+      return;
     }
+
     setTheme('light');
-  }
+  };
 
   // const [isClient, setIsClient] = React.useState(false);
   

--- a/src/providers/Providers.tsx
+++ b/src/providers/Providers.tsx
@@ -8,7 +8,11 @@ import { TooltipProvider } from "@/components/ui/tooltip"
 import { ThemeProvider } from "./theme-provider";
 import { Toaster } from "@/components/ui/toaster";
 
-export const Providers = ({children}: PropsWithChildren) => {
+type ProvidersProps = PropsWithChildren<{
+  initialTheme?: 'light' | 'dark';
+}>;
+
+export const Providers = ({ children, initialTheme }: ProvidersProps) => {
   // Create a client
   const queryClient = new QueryClient({
     defaultOptions: {
@@ -24,9 +28,10 @@ export const Providers = ({children}: PropsWithChildren) => {
       <TooltipProvider>   
         <ThemeProvider
           attribute="class"
-          defaultTheme="system"
+          defaultTheme={initialTheme ?? "dark"}
           enableSystem
           disableTransitionOnChange
+          storageKey="theme"
         >
           {children}
           <Toaster />


### PR DESCRIPTION
## Summary
- make the root layout async so Next.js 15 can await the cookie store
- await `cookies()` before reading the persisted theme value

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e18bcd580883328df63796ccec509b