### PR TITLE
Ensure system theme dark styling matches dark mode

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -46,24 +46,47 @@ export const metadata: Metadata = {
   },
 };
 
-export default function RootLayout({
+const themeInitializer = `(() => {
+  try {
+    const storedTheme = localStorage.getItem('theme');
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const theme = storedTheme === 'light' || storedTheme === 'dark'
+      ? storedTheme
+      : storedTheme === 'system'
+        ? (prefersDark ? 'dark' : 'light')
+        : (prefersDark ? 'dark' : 'light');
+
+    if (theme === 'dark') {
+      document.documentElement.classList.add('dark');
+    } else {
+      document.documentElement.classList.remove('dark');
+    }
+  } catch (error) {}
+})();`;
+
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
 
-  const cookieStore = cookies();
+  const cookieStore = await cookies();
   const themeCookie = cookieStore.get("theme")?.value;
   const initialTheme = themeCookie === "light" || themeCookie === "dark" ? themeCookie : undefined;
 
   return (
     <html lang="en" className={initialTheme === "dark" ? "dark" : ""} suppressHydrationWarning>
       <body className={`${nunito.className} ${titilum.className} antialiased`}>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: themeInitializer,
+          }}
+        />
         <Providers initialTheme={initialTheme}>
           {children}
           <SpeedInsights />
         </Providers>
-        
+
         <GoogleAnalytics />
       </body>
     </html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,28 +12,24 @@ import { FaLinkedinIn } from "react-icons/fa";
 
 export default function Page() {
   const [isContactOpen, setIsContactOpen] = React.useState<boolean>(false);
-  const { theme, setTheme, resolvedTheme } = useTheme();
+  const { theme, resolvedTheme } = useTheme();
 
   React.useEffect(() => {
+    if (!theme) {
+      return;
+    }
+
     const activeTheme = theme === 'system' ? resolvedTheme : theme;
 
-    if (!activeTheme) {
-      return;
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('theme', theme);
     }
 
-    document.cookie = `theme=${activeTheme}; path=/; max-age=${60 * 60 * 24 * 365}`;
+    if (activeTheme) {
+      document.documentElement.classList.toggle('dark', activeTheme === 'dark');
+      document.cookie = `theme=${activeTheme}; path=/; max-age=${60 * 60 * 24 * 365}`;
+    }
   }, [theme, resolvedTheme]);
-
-  const handleTheme = () => {
-    const currentTheme = theme === 'system' ? resolvedTheme : theme;
-
-    if (currentTheme === 'light') {
-      setTheme('dark');
-      return;
-    }
-
-    setTheme('light');
-  };
 
   // const [isClient, setIsClient] = React.useState(false);
   
@@ -58,11 +54,7 @@ export default function Page() {
       <CustomContactDialog isContactOpen={isContactOpen} setIsContactOpen={setIsContactOpen} />
 
       {/* FLOATING BUTTONS */}
-      <CustomFloatingButtons
-        isContactOpen={isContactOpen}
-        setIsContactOpen={setIsContactOpen}
-        handleTheme={handleTheme}
-      />
+      <CustomFloatingButtons />
 
       {/* FLOATING THEME TOGGLE BUTTON */}
       <div className="flex flex-grow relative z-10">

--- a/src/components/shared/CustomContactDialog.tsx
+++ b/src/components/shared/CustomContactDialog.tsx
@@ -33,7 +33,9 @@ export const CustomContactDialog = ({
 }: Props) => {
 
   const { sendContactMutation } = useContact();
-  const { theme } = useTheme();
+  const { theme, resolvedTheme } = useTheme();
+  const activeTheme = theme === "system" ? resolvedTheme : theme;
+  const isDark = activeTheme === "dark";
 
   // 1. Define your form.
   const form = useForm<z.infer<typeof formSchema>>({
@@ -145,7 +147,7 @@ export const CustomContactDialog = ({
               type="submit"
               className={`
                 px-4 rounded-md text-sm
-                ${theme === 'dark'
+                ${isDark
                   ? 'border-gradient bg-transparent text-gradient-light hover:bg-gradient-to-r hover:from-orange-500/10 hover:to-orange-600/10'
                   : 'border border-[#bfbfbf] text-gray-700 hover:bg-gray-200'
                 }

--- a/src/components/shared/CustomFloatingButtons.tsx
+++ b/src/components/shared/CustomFloatingButtons.tsx
@@ -5,34 +5,102 @@ import { FaLinkedinIn } from "react-icons/fa";
 import { FiGithub } from "react-icons/fi";
 import { CgDarkMode } from "react-icons/cg";
 import { CustomFloatingButtonsSkeleton } from "./CustomFloatingButtonsSkeleton";
+import { useTheme } from "next-themes";
 
-interface Props {
-  isContactOpen: boolean;
-  setIsContactOpen: React.Dispatch<React.SetStateAction<boolean>>;
-  handleTheme: () => void;
-}
+type ThemeOption = "light" | "dark" | "system";
 
-export const CustomFloatingButtons = ({ handleTheme }: Props) => {
+const THEME_OPTIONS: { label: string; value: ThemeOption }[] = [
+  { label: "Light", value: "light" },
+  { label: "Dark", value: "dark" },
+  { label: "System", value: "system" },
+];
+
+export const CustomFloatingButtons = () => {
   const [isClient, setIsClient] = React.useState(false);
 
   const [showTooltip, setShowTooltip] = React.useState(false);
+  const [isThemeMenuOpen, setIsThemeMenuOpen] = React.useState(false);
+
+  const { theme, setTheme, resolvedTheme } = useTheme();
+
+  const themeButtonRef = React.useRef<HTMLDivElement | null>(null);
+
+  React.useEffect(() => {
+    if (!isThemeMenuOpen) {
+      return;
+    }
+
+    const handleClickOutside = (event: MouseEvent) => {
+      if (themeButtonRef.current && !themeButtonRef.current.contains(event.target as Node)) {
+        setIsThemeMenuOpen(false);
+      }
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [isThemeMenuOpen]);
 
   React.useEffect(() => {
     setIsClient(true);
   }, []);
 
+  const handleThemeSelection = (value: ThemeOption) => {
+    setTheme(value);
+    if (typeof window !== "undefined") {
+      localStorage.setItem("theme", value);
+    }
+    setIsThemeMenuOpen(false);
+  };
+
   if (!isClient) return <CustomFloatingButtonsSkeleton />;
+
+  const isSystemTheme = theme === "system";
+  const resolved = isSystemTheme ? resolvedTheme : theme;
 
   return (
     <>
       {/* FLOATING THEME BUTTON */}
-      <div className="fixed top-6 right-6 z-50 flex flex-col gap-2">
+      <div
+        className="fixed top-6 right-6 z-50 flex flex-col items-end gap-2"
+        ref={themeButtonRef}
+      >
         <button
-          onClick={handleTheme}
+          onClick={() => setIsThemeMenuOpen((prev) => !prev)}
           className="flex items-center justify-center w-10 h-10 bg-gray-200 dark:bg-gray-900 text-gray-800 dark:text-gray-400 rounded-full transition-all duration-300 ease-in-out transform hover:scale-110 border border-gray-300 dark:border-gray-800"
+          aria-label="Toggle theme options"
         >
           <CgDarkMode />
         </button>
+
+        {isThemeMenuOpen && (
+          <div className="absolute right-0 top-full mt-2 w-36 rounded-xl border border-gray-200 bg-white p-2 shadow-lg dark:border-gray-800 dark:bg-gray-950">
+            <span className="block px-2 pb-1 text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">
+              Theme
+            </span>
+            <div className="flex flex-col gap-1">
+              {THEME_OPTIONS.map((option) => {
+                const isActive = option.value === "system" ? isSystemTheme : !isSystemTheme && resolved === option.value;
+
+                return (
+                  <button
+                    key={option.value}
+                    onClick={() => handleThemeSelection(option.value)}
+                    className={`w-full rounded-lg border px-3 py-2 text-left text-sm transition-colors ${
+                      isActive
+                        ? "border-gray-900 bg-gray-900 text-gray-100 dark:border-gray-100 dark:bg-gray-100 dark:text-gray-900"
+                        : "border-gray-200 bg-gray-50 text-gray-700 hover:bg-gray-100 dark:border-gray-800 dark:bg-gray-900 dark:text-gray-300 dark:hover:bg-gray-800"
+                    }`}
+                  >
+                    {option.label}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        )}
       </div>
 
       {/* FLOATING SOCIAL BUTTONS */}

--- a/src/components/shared/CustomGradientText.tsx
+++ b/src/components/shared/CustomGradientText.tsx
@@ -5,7 +5,7 @@ import { Skeleton } from "@/components/ui/skeleton"
 
 export const CustomGradientText = ({ children }: PropsWithChildren) => {
   const [isClient, setIsClient] = React.useState(false);
-  const { theme } = useTheme();
+  const { theme, resolvedTheme } = useTheme();
 
   React.useEffect(() => {
       setIsClient(true); // Establece el estado después de que se haya renderizado en el cliente
@@ -13,9 +13,10 @@ export const CustomGradientText = ({ children }: PropsWithChildren) => {
   
     if (!isClient) return <Skeleton className="w-[100px] h-9 rounded" />;
 
-  return <span className={
-    theme === 'dark'
-      ? `${['text-gradient-light']}`
-      : 'text-black'
-  }>{children}</span>;
+  const activeTheme = theme === "system" ? resolvedTheme : theme;
+  const isDark = activeTheme === "dark";
+
+  return (
+    <span className={isDark ? `${['text-gradient-light']}` : "text-black"}>{children}</span>
+  );
 };

--- a/src/components/shared/CustomHeroTitle.tsx
+++ b/src/components/shared/CustomHeroTitle.tsx
@@ -6,7 +6,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 
 export const CustomHeroTitle = () => {
   const [isClient, setIsClient] = React.useState(false);
-  const { theme } = useTheme();
+  const { theme, resolvedTheme } = useTheme();
 
   React.useEffect(() => {
     setIsClient(true);
@@ -18,13 +18,12 @@ export const CustomHeroTitle = () => {
     </div>
   );
 
+  const activeTheme = theme === "system" ? resolvedTheme : theme;
+  const isDark = activeTheme === "dark";
+
   return (
     <h1 className="flex gap-2 text-3xl uppercase mb-5">
-      Hola, Soy <span className={
-        theme === 'dark'
-          ? `text-gradient-light`
-          : 'text-black'
-      }>Derky</span>
+      Hola, Soy <span className={isDark ? `text-gradient-light` : "text-black"}>Derky</span>
     </h1>
   );
 };

--- a/src/components/shared/CustomLogo.tsx
+++ b/src/components/shared/CustomLogo.tsx
@@ -12,13 +12,16 @@ import { Skeleton } from "@/components/ui/skeleton";
 
 export const CustomLogo = () => {
   const [isClient, setIsClient] = React.useState(false);
-  const { theme } = useTheme();
+  const { theme, resolvedTheme } = useTheme();
 
   React.useEffect(() => {
     setIsClient(true); // Establece el estado después de que se haya renderizado en el cliente
   }, []);
 
   if (!isClient) return <Skeleton className="w-[40px] h-[50px] rounded" />; // Skeleton con las mismas dimensiones del logo
+
+  const activeTheme = theme === "system" ? resolvedTheme : theme;
+  const isDark = activeTheme === "dark";
 
   return (
     <motion.div
@@ -34,7 +37,7 @@ export const CustomLogo = () => {
       }}
     >
       <div className="hover:scale-110 hover:-rotate-3 transition-all duration-200 ease-in-out">
-        {theme === 'dark'
+        {isDark
           ? <Image src={'/assets/svg/san.svg'} width={40} height={45} alt={"San"} className="transition-all duration-200 ease-in-out" />
           : <Image src={'/assets/svg/san-black.svg'} width={40} height={45} alt={"San"} className="transition-all duration-200 ease-in-out" />
         }


### PR DESCRIPTION
## Summary
- persist the user’s theme choice and sync the `<html>` dark class and cookie on load
- add a floating theme menu with Light, Dark, and System options backed by Tailwind’s `dark:` styles
- hydrate the page with the stored theme by injecting a pre-hydration script to reduce flashes
- ensure the brand logo and gradient text honor the resolved dark theme when the System option prefers dark
- keep the floating theme toggle anchored by positioning its dropdown absolutely when opened

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e1e51027688332b8d70542f3018ce5