### PR TITLE
Respect system theme on first visit

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -49,12 +49,15 @@ export const metadata: Metadata = {
 const themeInitializer = `(() => {
   try {
     const storedTheme = localStorage.getItem('theme');
+    const storedPreference = localStorage.getItem('theme-preference');
     const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
     const theme = storedTheme === 'light' || storedTheme === 'dark'
       ? storedTheme
-      : storedTheme === 'system'
-        ? (prefersDark ? 'dark' : 'light')
-        : (prefersDark ? 'dark' : 'light');
+      : storedPreference === 'light' || storedPreference === 'dark'
+        ? storedPreference
+        : storedPreference === 'system'
+          ? (prefersDark ? 'dark' : 'light')
+          : (prefersDark ? 'dark' : 'light');
 
     if (theme === 'dark') {
       document.documentElement.classList.add('dark');

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -15,14 +15,15 @@ export default function Page() {
   const { theme, resolvedTheme } = useTheme();
 
   React.useEffect(() => {
-    if (!theme) {
+    if (!theme || (theme === 'system' && !resolvedTheme)) {
       return;
     }
 
     const activeTheme = theme === 'system' ? resolvedTheme : theme;
 
-    if (typeof window !== 'undefined') {
-      localStorage.setItem('theme', theme);
+    if (activeTheme && typeof window !== 'undefined') {
+      localStorage.setItem('theme', activeTheme);
+      localStorage.setItem('theme-preference', theme);
     }
 
     if (activeTheme) {

--- a/src/components/shared/CustomFloatingButtons.tsx
+++ b/src/components/shared/CustomFloatingButtons.tsx
@@ -50,7 +50,10 @@ export const CustomFloatingButtons = () => {
   const handleThemeSelection = (value: ThemeOption) => {
     setTheme(value);
     if (typeof window !== "undefined") {
-      localStorage.setItem("theme", value);
+      localStorage.setItem("theme-preference", value);
+      if (value === "light" || value === "dark") {
+        localStorage.setItem("theme", value);
+      }
     }
     setIsThemeMenuOpen(false);
   };

--- a/src/providers/Providers.tsx
+++ b/src/providers/Providers.tsx
@@ -28,10 +28,10 @@ export const Providers = ({ children, initialTheme }: ProvidersProps) => {
       <TooltipProvider>   
         <ThemeProvider
           attribute="class"
-          defaultTheme={initialTheme ?? "dark"}
+          defaultTheme={initialTheme ?? "system"}
           enableSystem
           disableTransitionOnChange
-          storageKey="theme"
+          storageKey="theme-preference"
         >
           {children}
           <Toaster />


### PR DESCRIPTION
## Summary
- default the theme provider to system when no cookie is set
- ensure the hydration script falls back to the system theme and uses stored preferences
- persist both the active theme and the saved preference in local storage

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e1ff8e5f6c8332a5b7b77bc7bf21e6