### PR TITLE
Fix theme dropdown alignment

### DIFF
--- a/src/components/shared/CustomFloatingButtons.tsx
+++ b/src/components/shared/CustomFloatingButtons.tsx
@@ -66,7 +66,10 @@ export const CustomFloatingButtons = () => {
   return (
     <>
       {/* FLOATING THEME BUTTON */}
-      <div className="fixed top-6 right-6 z-50 flex flex-col gap-2" ref={themeButtonRef}>
+      <div
+        className="fixed top-6 right-6 z-50 flex flex-col items-end gap-2"
+        ref={themeButtonRef}
+      >
         <button
           onClick={() => setIsThemeMenuOpen((prev) => !prev)}
           className="flex items-center justify-center w-10 h-10 bg-gray-200 dark:bg-gray-900 text-gray-800 dark:text-gray-400 rounded-full transition-all duration-300 ease-in-out transform hover:scale-110 border border-gray-300 dark:border-gray-800"


### PR DESCRIPTION
## Summary
- keep the floating theme toggle button anchored while the menu is open by right-aligning the stack

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e28aad5de4833287a23dfed017d914