### PR TITLE
Ocultar selector de tema y forzar modo oscuro por defecto

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,7 +4,6 @@ import "./globals.css";
 import { Nunito, Titillium_Web } from 'next/font/google'
 
 import { Providers } from "@/providers";
-import { cookies } from "next/headers";
 
 import { SpeedInsights } from "@vercel/speed-insights/next"
 import { GoogleAnalytics } from "@/components/shared";
@@ -48,17 +47,8 @@ export const metadata: Metadata = {
 
 const themeInitializer = `(() => {
   try {
-    const storedTheme = localStorage.getItem('theme');
-    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-    const theme = storedTheme === 'light' || storedTheme === 'dark'
-      ? storedTheme
-      : (prefersDark ? 'dark' : 'light');
-
-    if (theme === 'dark') {
-      document.documentElement.classList.add('dark');
-    } else {
-      document.documentElement.classList.remove('dark');
-    }
+    localStorage.setItem('theme', 'dark');
+    document.documentElement.classList.add('dark');
   } catch (error) {}
 })();`;
 
@@ -67,20 +57,15 @@ export default async function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-
-  const cookieStore = await cookies();
-  const themeCookie = cookieStore.get("theme")?.value;
-  const initialTheme = themeCookie === "light" || themeCookie === "dark" ? themeCookie : undefined;
-
   return (
-    <html lang="en" className={initialTheme === "dark" ? "dark" : ""} suppressHydrationWarning>
+    <html lang="en" className="dark" suppressHydrationWarning>
       <body className={`${nunito.className} ${titilum.className} antialiased`}>
         <script
           dangerouslySetInnerHTML={{
             __html: themeInitializer,
           }}
         />
-        <Providers initialTheme={initialTheme}>
+        <Providers initialTheme="dark">
           {children}
           <SpeedInsights />
         </Providers>

--- a/src/components/shared/CustomFloatingButtons.tsx
+++ b/src/components/shared/CustomFloatingButtons.tsx
@@ -3,63 +3,21 @@
 import React from "react";
 import { FaLinkedinIn } from "react-icons/fa";
 import { FiGithub } from "react-icons/fi";
-import { CgShapeCircle } from "react-icons/cg";
-import { PiSunDimBold } from "react-icons/pi";
 import { CustomFloatingButtonsSkeleton } from "./CustomFloatingButtonsSkeleton";
-import { useTheme } from "next-themes";
 import { motion } from "framer-motion";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
 export const CustomFloatingButtons = () => {
   const [isClient, setIsClient] = React.useState(false);
-  const [iconKey, setIconKey] = React.useState(0);
-
-  const { theme, setTheme } = useTheme();
 
   React.useEffect(() => {
     setIsClient(true);
   }, []);
 
-  const toggleTheme = () => {
-    const newTheme = theme === "light" ? "dark" : "light";
-    setTheme(newTheme);
-    setIconKey(prev => prev + 1);
-  };
-
   if (!isClient) return <CustomFloatingButtonsSkeleton />;
 
   return (
     <>
-      {/* FLOATING THEME BUTTON */}
-      <div className="fixed top-6 right-6 z-50">
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <button
-              onClick={toggleTheme}
-              className="flex items-center justify-center w-10 h-10 text-gray-800 dark:text-gray-400 rounded-full"
-              aria-label="Toggle theme"
-            >
-              <motion.div
-                key={iconKey}
-                initial={{ scale: 0.5 }}
-                animate={{ scale: 1 }}
-                transition={{
-                  type: "spring",
-                  stiffness: 260,
-                  damping: 10,
-                  duration: 0.6
-                }}
-              >
-                {theme === "dark" ? <CgShapeCircle /> : <PiSunDimBold />}
-              </motion.div>
-            </button>
-          </TooltipTrigger>
-          <TooltipContent side="left">
-            <p>Cambiar tema a {theme === "dark" ? "claro" : "oscuro"}</p>
-          </TooltipContent>
-        </Tooltip>
-      </div>
-
       {/* FLOATING SOCIAL BUTTONS */}
       <div className="fixed bottom-6 items justify-end right-6 z-50 flex gap-4 md:flex-col left-6 mx-auto md:left-auto md:gap-2">
         <Tooltip>

--- a/src/providers/Providers.tsx
+++ b/src/providers/Providers.tsx
@@ -29,6 +29,7 @@ export const Providers = ({ children, initialTheme }: ProvidersProps) => {
         <ThemeProvider
           attribute="class"
           defaultTheme={initialTheme ?? "dark"}
+          forcedTheme="dark"
           enableSystem={false}
           disableTransitionOnChange
           storageKey="theme"


### PR DESCRIPTION
### Motivation
- Asegurar que la web arranque siempre en tema oscuro y evitar que el usuario cambie el theme desde el UI flotante.

### Description
- Eliminé el botón y la lógica de cambio de tema del componente `src/components/shared/CustomFloatingButtons.tsx`, dejando solo los botones sociales.
- Forcé el tema oscuro en el provider global añadiendo `forcedTheme="dark"` en `src/providers/Providers.tsx` y dejando `defaultTheme` en `dark`.
- Simplifiqué la inicialización en `src/app/layout.tsx` para siempre escribir `theme = 'dark'` en `localStorage` y renderizar `<html class="dark">` de entrada.

### Testing
- Ejecuté `npm run lint` y no arrojó warnings ni errores (✅).
- Levanté la app con `npm run dev` y verifiqué visualmente la página principal con una captura de pantalla que confirma el modo oscuro y la ausencia del toggle (✅).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a9e5f28f88332969bf1a7002bc4de)