### PR TITLE
feat(sidebar): habilitar sidebar y rediseñar UI desktop/mobile

### DIFF
--- a/src/components/layouts/SidebarLayout.tsx
+++ b/src/components/layouts/SidebarLayout.tsx
@@ -1,9 +1,11 @@
 "use client"
 
 import React from "react"
+import { AnimatePresence, motion } from "motion/react"
 import { SideBar, type SidebarMenuItem } from "../shared/SideBar"
 import { CustomLogo } from "../shared/CustomLogo"
 import {
+  ArrowUpRight,
   Menu,
   X,
   Mail,
@@ -14,6 +16,16 @@ import {
 } from "lucide-react"
 import { FaLinkedinIn } from "react-icons/fa";
 import { FiGithub } from "react-icons/fi";
+
+const SIDEBAR_BRAND_TRANSITION = {
+  duration: 0.3,
+  ease: [0.4, 0, 0.2, 1] as [number, number, number, number],
+}
+
+const MOBILE_PANEL_TRANSITION = {
+  duration: 0.32,
+  ease: [0.4, 0, 0.2, 1] as [number, number, number, number],
+}
 
 interface SidebarLayoutProps {
   children: React.ReactNode
@@ -49,30 +61,44 @@ export const SidebarLayout: React.FC<SidebarLayoutProps> = ({
       icon: <FiGithub className="h-5 w-5" />,
       href: "https://github.com/Derkysan",
     },
-    {
-      id: "linkedin",
-      label: "LinkedIn",
-      icon: <FaLinkedinIn className="h-5 w-5" />,
-      href: "https://www.linkedin.com/in/derkysan/",
-    },
+    // {
+    //   id: "linkedin",
+    //   label: "LinkedIn",
+    //   icon: <FaLinkedinIn className="h-5 w-5" />,
+    //   href: "https://www.linkedin.com/in/derkysan/",
+    // },
     {
       id: "email",
       label: "Contactar",
       icon: <Mail className="h-5 w-5" />,
-      href: "mailto:contacto@derkysan.dev",
+      href: "mailto:derkysan.dev@gmail.com",
     },
   ]
 
   const defaultBrand = (expanded: boolean) => (
-    <div className="flex items-center gap-3">
-      <div className="border rounded-full w-10 aspect-square">
+    <div className="flex min-w-0 items-center gap-3">
+      <div className="flex h-10 w-10 shrink-0 items-center justify-center">
         <CustomLogo active={expanded} />
       </div>
+      <AnimatePresence initial={false}>
+        {expanded && (
+          <motion.span
+            key="brand-text"
+            initial={{ opacity: 0, width: 0, x: -10 }}
+            animate={{ opacity: 1, width: "auto", x: 0 }}
+            exit={{ opacity: 0, width: 0, x: -10 }}
+            transition={SIDEBAR_BRAND_TRANSITION}
+            className="overflow-hidden whitespace-nowrap text-sm tracking-[0.24em] font-mono"
+          >
+            DERKYSAN
+          </motion.span>
+        )}
+      </AnimatePresence>
     </div>
   )
 
   const defaultFooter = (isExpanded: boolean) => (
-    <div className="space-y-3">
+    <div className="flex h-full w-full items-center justify-center overflow-hidden">
       {/* Theme Toggle */}
       {/* <Button
         variant="outline"
@@ -122,12 +148,12 @@ export const SidebarLayout: React.FC<SidebarLayoutProps> = ({
       {/* </div> */}
 
       {/* Version */}
-      <div className="flex flex-col gap-y-0 items-center justify-center text-xs text-muted-foreground whitespace-nowrap">
+      <div className={`flex ${isExpanded ? "flex-row w-full text-left justify-start pl-4" : "flex-col gap-y-0"}  text-[10px] text-muted-foreground whitespace-nowrap leading-tight`}>
         {/* v1.0.0 */}
-        <span className={`transition-all duration-300 ease-in-out overflow-hidden ${isExpanded ? "w-auto opacity-100" : "w-0 opacity-0"}`}>© copyright</span>
+        <span className={`transition-all duration-300 ease-in-out overflow-hidden text-nowrap uppercase ${isExpanded ? "w-auto opacity-100" : "w-0 opacity-0"}`}>© copyright</span>
         {/* <span>{new Date().getFullYear()}</span> */}
-        <span>20</span>
-        <span>26</span>
+        <span className={`${isExpanded ? 'text-gray-100' : 'text-white'}`}>20</span>
+        <span className={`${isExpanded ? 'text-gray-100' : 'text-white'}`}>26</span>
       </div>
     </div>
   )
@@ -158,46 +184,175 @@ export const SidebarLayout: React.FC<SidebarLayoutProps> = ({
     },
   }))
 
+  const handleMobileItemClick = (item: SidebarMenuItem) => {
+    item.onClick?.()
+    setMobileMenuOpen(false)
+  }
+
   return (
     <div className="flex h-screen overflow-hidden">
-      <header className="fixed inset-x-0 top-0 z-40 flex h-14 items-center justify-between border-b border-[#F07D00] bg-background/95 px-4 backdrop-blur md:hidden">
-        <div className="h-8 w-8">
-          <CustomLogo />
+      <header className="fixed inset-x-0 top-0 z-40 flex h-16 items-center justify-between border-[#F07D00]/20 bg-background/80 px-4 backdrop-blur-xl md:hidden">
+        <div className="flex items-center gap-3 rounded-full border border-[#F07D00]/20 bg-background/80 px-3 py-2 shadow-[0_8px_24px_rgba(0,0,0,0.18)]">
+          <div className="h-8 w-8 shrink-0 overflow-hidden">
+            <CustomLogo contained />
+          </div>
+          <span className="text-[11px] tracking-[0.28em] text-foreground/80">DERKYSAN</span>
         </div>
         <button
           type="button"
           onClick={() => setMobileMenuOpen((prev) => !prev)}
           aria-label={mobileMenuOpen ? "Cerrar menú" : "Abrir menú"}
-          className="inline-flex h-9 w-9 items-center justify-center rounded-md border border-[#F07D00]/40 text-primary transition-colors hover:bg-accent"
+          className="inline-flex h-11 w-11 items-center justify-center rounded-full border-[#F07D00]/30 bg-background/80 text-primary shadow-[0_8px_24px_rgba(0,0,0,0.18)] transition-colors hover:bg-accent"
         >
           {mobileMenuOpen ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
         </button>
       </header>
 
-      {mobileMenuOpen && (
-        <div className="fixed inset-0 z-50 md:hidden" aria-hidden={!mobileMenuOpen}>
-          <button
-            type="button"
-            aria-label="Cerrar menú"
-            className="absolute inset-0 bg-black/45"
-            onClick={() => setMobileMenuOpen(false)}
-          />
-          <div className="relative z-10 h-full">
-            <SideBar
-              className="h-dvh"
-              brand={customBrand || defaultBrand}
-              menuItems={mobileMenuItems}
-              footer={customFooter || defaultFooter}
-              expanded={true}
-              expandOnHover={false}
-              expandedWidth="84vw"
-              collapsedWidth="84vw"
+      <AnimatePresence>
+        {mobileMenuOpen && (
+          <div className="fixed inset-0 z-50 md:hidden" aria-hidden={!mobileMenuOpen}>
+            <motion.button
+              type="button"
+              aria-label="Cerrar menú"
+              className="absolute inset-0 bg-black/55 backdrop-blur-sm"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={MOBILE_PANEL_TRANSITION}
+              onClick={() => setMobileMenuOpen(false)}
             />
-          </div>
-        </div>
-      )}
+            <motion.div
+              initial={{ opacity: 0, y: 24, scale: 0.98 }}
+              animate={{ opacity: 1, y: 0, scale: 1 }}
+              exit={{ opacity: 0, y: 20, scale: 0.98 }}
+              transition={MOBILE_PANEL_TRANSITION}
+              className="absolute inset-x-3 bottom-3 top-3 overflow-hidden rounded-[28px] border border-[#F07D00]/25 bg-background/92 shadow-[0_24px_80px_rgba(0,0,0,0.45)] backdrop-blur-2xl"
+            >
+              <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_right,rgba(240,125,0,0.18),transparent_34%),linear-gradient(180deg,rgba(255,255,255,0.03),transparent_18%)]" />
 
-      <div className="hidden md:block">
+              <div className="relative flex h-full flex-col px-5 pb-5 pt-4">
+                <div className="flex items-start justify-between gap-4 border-b border-[#F07D00]/15 pb-4">
+                  {customBrand ? (
+                    <div className="min-w-0 flex-1 overflow-hidden">
+                      {customBrand}
+                    </div>
+                  ) : (
+                    <div className="flex min-w-0 items-center gap-3">
+                      <div className="flex h-12 w-12 items-center justify-center overflow-hidden">
+                        <CustomLogo active contained />
+                      </div>
+                      <div className="min-w-0">
+                        <p className="text-[11px] uppercase tracking-[0.28em] text-foreground/60">
+                          Menu
+                        </p>
+                        <p className="truncate text-sm tracking-[0.22em] text-foreground">
+                          DERKYSAN
+                        </p>
+                      </div>
+                    </div>
+                  )}
+
+                  <button
+                    type="button"
+                    onClick={() => setMobileMenuOpen(false)}
+                    aria-label="Cerrar menú"
+                    className="inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-full border border-[#F07D00]/20 bg-background/80 text-primary transition-colors hover:bg-accent"
+                  >
+                    <X className="h-5 w-5" />
+                  </button>
+                </div>
+
+                <div className="flex-1 overflow-y-auto py-6">
+                  <motion.div
+                    initial="hidden"
+                    animate="show"
+                    exit="hidden"
+                    variants={{
+                      hidden: {},
+                      show: {
+                        transition: {
+                          staggerChildren: 0.05,
+                          delayChildren: 0.04,
+                        },
+                      },
+                    }}
+                    className="space-y-3"
+                  >
+                    {mobileMenuItems.map((item) => {
+                      const isExternalLink = !!item.href && /^(https?:\/\/|mailto:)/i.test(item.href)
+                      const itemClasses =
+                        "group flex w-full items-center gap-4 rounded-2xl border border-white/10 bg-white/[0.03] px-4 py-4 text-left transition-all duration-300 ease-in-out hover:border-[#F07D00]/30 hover:bg-white/[0.06]"
+
+                      const content = (
+                        <>
+                          <span className="flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl border border-[#F07D00]/20 bg-[#F07D00]/10 text-[#F7A23B]">
+                            {item.icon}
+                          </span>
+                          <span className="min-w-0 flex-1">
+                            <span className="block truncate text-sm text-foreground">
+                              {item.label}
+                            </span>
+                            <span className="block truncate pt-1 text-[11px] uppercase tracking-[0.18em] text-foreground/45">
+                              {item.href?.replace(/^mailto:/, "") || "Abrir"}
+                            </span>
+                          </span>
+                          <ArrowUpRight className="h-4 w-4 shrink-0 text-foreground/35 transition-transform duration-300 ease-in-out group-hover:-translate-y-0.5 group-hover:translate-x-0.5 group-hover:text-[#F7A23B]" />
+                        </>
+                      )
+
+                      return (
+                        <motion.div
+                          key={item.id}
+                          variants={{
+                            hidden: { opacity: 0, y: 14 },
+                            show: { opacity: 1, y: 0 },
+                          }}
+                          transition={MOBILE_PANEL_TRANSITION}
+                        >
+                          {item.href ? (
+                            <a
+                              href={item.href}
+                              target={isExternalLink ? "_blank" : undefined}
+                              rel={isExternalLink ? "noopener noreferrer" : undefined}
+                              onClick={() => handleMobileItemClick(item)}
+                              className={itemClasses}
+                            >
+                              {content}
+                            </a>
+                          ) : (
+                            <button
+                              type="button"
+                              onClick={() => handleMobileItemClick(item)}
+                              className={itemClasses}
+                            >
+                              {content}
+                            </button>
+                          )}
+                        </motion.div>
+                      )
+                    })}
+                  </motion.div>
+                </div>
+
+                <div className="border-t border-[#F07D00]/15 pt-4">
+                  {customFooter ? (
+                    <div className="overflow-hidden rounded-2xl border border-white/10 bg-white/[0.03] p-4">
+                      {customFooter}
+                    </div>
+                  ) : (
+                    <div className="flex items-center justify-between gap-3 rounded-2xl border border-white/10 bg-white/[0.03] px-4 py-3 text-[11px] uppercase tracking-[0.16em] text-foreground/55">
+                      <span>© 2026</span>
+                      <span className="text-[#F7A23B]">Software Developer</span>
+                    </div>
+                  )}
+                </div>
+              </div>
+            </motion.div>
+          </div>
+        )}
+      </AnimatePresence>
+
+      <div className="hidden md:block p-3">
         <SideBar
           brand={customBrand || defaultBrand}
           menuItems={resolvedMenuItems}

--- a/src/components/shared/CustomLogo.tsx
+++ b/src/components/shared/CustomLogo.tsx
@@ -6,13 +6,18 @@ import { motion } from "motion/react";
 
 import { useTheme } from "@/providers/theme-provider";
 import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
 // import { SanLogo, SanLogoBlack } from "../../../public";
 
 interface CustomLogoProps {
   active?: boolean;
+  contained?: boolean;
 }
 
-export const CustomLogo: React.FC<CustomLogoProps> = ({ active = false }) => {
+export const CustomLogo: React.FC<CustomLogoProps> = ({
+  active = false,
+  contained = false,
+}) => {
   const [isClient, setIsClient] = React.useState(false);
   const { theme, resolvedTheme } = useTheme();
 
@@ -24,6 +29,11 @@ export const CustomLogo: React.FC<CustomLogoProps> = ({ active = false }) => {
 
   const activeTheme = theme === "system" ? resolvedTheme : theme;
   const isDark = activeTheme === "dark";
+  const restingScale = contained ? 1 : 1.5;
+  const activeScale = contained ? 1 : 1.25;
+  const hoverScale = contained ? 1 : 1.5;
+  const logoWidth = contained ? 24 : 40;
+  const logoHeight = contained ? 28 : 45;
 
   return (
     <motion.div
@@ -37,17 +47,21 @@ export const CustomLogo: React.FC<CustomLogoProps> = ({ active = false }) => {
         damping: 20,
         delay: 0.1
       }}
+      className={cn(contained && "flex h-full w-full items-center justify-center")}
     >
       <motion.div
         initial={false}
-        animate={{ scale: active ? 1.5 : 1.25, rotate: active ? -2 : 0 }}
-        whileHover={{ scale: 1.5, rotate: -2 }}
+        animate={{ scale: active ? activeScale : restingScale }}
+        whileHover={{ scale: hoverScale }}
         transition={{ duration: 0.2, ease: "easeInOut" }}
-        className="bg-background/80 backdrop-blur-2xl p-2 rounded-lg shadow-3xl shadow-gray-300/50 dark:shadow-gray-950/50"
+        className={cn(
+          "flex items-center justify-center",
+          contained ? "p-1.5" : "p-2"
+        )}
       >
         {isDark
-          ? <img src={'/assets/svg/san.svg'} width={40} height={45} alt={"San"} className="transition-all duration-200 ease-in-out" />
-          : <img src={'/assets/svg/san.svg'} width={40} height={45} alt={"San"} className="transition-all duration-200 ease-in-out" />
+          ? <img src={'/assets/svg/san.svg'} width={logoWidth} height={logoHeight} alt={"San"} className="block transition-all duration-200 ease-in-out" />
+          : <img src={'/assets/svg/san.svg'} width={logoWidth} height={logoHeight} alt={"San"} className="block transition-all duration-200 ease-in-out" />
           // : <img src={'/assets/svg/san-black.svg'} width={40} height={45} alt={"San"} className="transition-all duration-200 ease-in-out" />
         }
       </motion.div>

--- a/src/components/shared/SideBar.tsx
+++ b/src/components/shared/SideBar.tsx
@@ -13,6 +13,13 @@ import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
 
+const SIDEBAR_TRANSITION_DURATION = 0.3
+const SIDEBAR_TRANSITION_EASE: [number, number, number, number] = [0.4, 0, 0.2, 1]
+const SIDEBAR_LABEL_TRANSITION = {
+  duration: SIDEBAR_TRANSITION_DURATION,
+  ease: SIDEBAR_TRANSITION_EASE,
+}
+
 // Types
 export interface SidebarMenuItem {
   id: string
@@ -61,7 +68,7 @@ export const SideBar = React.forwardRef<HTMLElement, SidebarProps>(
       expanded: controlledExpanded,
       onExpandedChange,
       className,
-      expandedWidth = "180px",
+      expandedWidth = "200px",
       collapsedWidth = "72px",
       children,
     },
@@ -100,18 +107,34 @@ export const SideBar = React.forwardRef<HTMLElement, SidebarProps>(
         <motion.aside
           ref={ref}
           className={cn(
-            "relative flex flex-col h-screen bg-background border-r border-[#F07D00] transition-all duration-100 ease-linear",
+            "relative flex flex-col h-full bg-background border rounded-xl transition-colors duration-300 ease-in-out overflow-hidden",
+            actualExpanded ? "border-[#603100]" : "border-transparent",
             className
           )}
           initial={false}
           animate={{ width: actualExpanded ? expandedWidth : collapsedWidth }}
+          transition={{ duration: SIDEBAR_TRANSITION_DURATION, ease: SIDEBAR_TRANSITION_EASE }}
           onMouseEnter={handleMouseEnter}
           onMouseLeave={handleMouseLeave}
         >
+          <motion.div
+            aria-hidden="true"
+            className="pointer-events-none absolute inset-0"
+            initial={false}
+            animate={{
+              opacity: actualExpanded ? 1 : 0,
+            }}
+            transition={{ duration: SIDEBAR_TRANSITION_DURATION, ease: SIDEBAR_TRANSITION_EASE }}
+            style={{
+              background:
+                "radial-gradient(circle at top right, rgba(240,125,0,0.18), transparent 34%), linear-gradient(180deg, rgba(255,255,255,0.03), transparent 18%)",
+            }}
+          />
+
           {/* Header/Brand Area */}
-          <SidebarHeader>
+          <SidebarHeader expanded={actualExpanded}>
             <div className={cn(
-              "flex items-center px-4 py-6",
+              "relative z-10 flex min-w-0 items-center overflow-hidden px-4 py-6",
               // !actualExpanded && "justify-center px-2"
             )}>
               {resolvedBrand || (
@@ -121,7 +144,7 @@ export const SideBar = React.forwardRef<HTMLElement, SidebarProps>(
           </SidebarHeader>
 
           {/* Navigation Menu Area */}
-          <SidebarMenu>
+          <SidebarMenu expanded={actualExpanded}>
             {children || (
               <nav className="flex h-full flex-col justify-center space-y-1 px-2">
                 {menuItems.map((item) => (
@@ -153,15 +176,21 @@ SideBar.displayName = "SideBar"
 
 interface SidebarHeaderProps {
   children: React.ReactNode
+  expanded: boolean
   className?: string
 }
 
 export const SidebarHeader: React.FC<SidebarHeaderProps> = ({ 
   children, 
+  expanded,
   className 
 }) => {
   return (
-    <header className={cn("shrink-0 border-b border-[#F07D00]", className)}>
+    <header className={cn(
+      "shrink-0 overflow-hidden transition-colors duration-300 ease-in-out",
+      expanded ? "border-b-[#F07D00]" : "border-b-transparent",
+      className
+    )}>
       {children}
     </header>
   )
@@ -169,15 +198,21 @@ export const SidebarHeader: React.FC<SidebarHeaderProps> = ({
 
 interface SidebarMenuProps {
   children: React.ReactNode
+  expanded: boolean
   className?: string
 }
 
 export const SidebarMenu: React.FC<SidebarMenuProps> = ({ 
   children, 
+  expanded,
   className 
 }) => {
   return (
-    <div className={cn("flex-1 overflow-y-auto py-4", className)}>
+    <div className={cn(
+      "relative z-10 flex-1 overflow-y-auto py-4 transition-opacity duration-300 ease-in-out",
+      expanded ? "opacity-100" : "opacity-35",
+      className
+    )}>
       {children}
     </div>
   )
@@ -196,8 +231,9 @@ export const SidebarFooter: React.FC<SidebarFooterProps> = ({
 }) => {
   return (
     <footer className={cn(
-      "shrink-0 border-t border-[#F07D00] p-4",
-      !expanded && "px-2",
+      "relative z-10 flex h-24 shrink-0 items-center justify-center overflow-hidden px-4 transition-[color,border-color,opacity] duration-300 ease-in-out",
+      expanded ? "border-t-[#F07D00]" : "border-t-transparent",
+      expanded ? "opacity-100" : "opacity-50",
       className
     )}>
       {children}
@@ -217,7 +253,7 @@ const SidebarMenuItem: React.FC<SidebarMenuItemProps> = ({ item, expanded }) => 
     <Button
       variant="ghost"
       className={cn(
-        "w-full justify-start gap-3 relative text-gray-400",
+        "relative w-full justify-start gap-3 overflow-hidden text-gray-400",
         
       )}
       onClick={item.onClick}
@@ -228,20 +264,22 @@ const SidebarMenuItem: React.FC<SidebarMenuItemProps> = ({ item, expanded }) => 
           href={item.href}
           target={isExternalLink ? "_blank" : undefined}
           rel={isExternalLink ? "noopener noreferrer" : undefined}
+          className="flex min-w-0 items-center gap-3 overflow-hidden"
         >
           <span className="shrink-0">{item.icon}</span>
-          <AnimatePresence mode="wait">
-            {/* {expanded && ( */}
+          <AnimatePresence initial={false}>
+            {expanded && (
               <motion.span
-                // initial={{ opacity: 0, width: 0 }}
-                animate={{ opacity: 1, width: "auto" }}
-                // exit={{ opacity: 0, width: 0 }}
-                transition={{ duration: 0.2 }}
-                className="overflow-hidden whitespace-nowrap"
+                key={`${item.id}-label`}
+                initial={{ opacity: 0, width: 0, x: -10 }}
+                animate={{ opacity: 1, width: "auto", x: 0 }}
+                exit={{ opacity: 0, width: 0, x: -10 }}
+                transition={SIDEBAR_LABEL_TRANSITION}
+                className="overflow-hidden whitespace-nowrap tracking-[0.24] font-mono text-xs text-gray-400 uppercase"
               >
                 {item.label}
               </motion.span>
-            {/* )} */}
+            )}
           </AnimatePresence>
           {item.badge && expanded && (
             <motion.span
@@ -257,13 +295,14 @@ const SidebarMenuItem: React.FC<SidebarMenuItemProps> = ({ item, expanded }) => 
       ) : (
         <>
           <span className="shrink-0">{item.icon}</span>
-          <AnimatePresence mode="wait">
+          <AnimatePresence initial={false}>
             {expanded && (
               <motion.span
-                initial={{ opacity: 0, width: 0 }}
-                animate={{ opacity: 1, width: "auto" }}
-                exit={{ opacity: 0, width: 0 }}
-                transition={{ duration: 0.2 }}
+                key={`${item.id}-label`}
+                initial={{ opacity: 0, width: 0, x: -10 }}
+                animate={{ opacity: 1, width: "auto", x: 0 }}
+                exit={{ opacity: 0, width: 0, x: -10 }}
+                transition={SIDEBAR_LABEL_TRANSITION}
                 className="overflow-hidden whitespace-nowrap"
               >
                 {item.label}

--- a/src/config/sidebar.config.ts
+++ b/src/config/sidebar.config.ts
@@ -7,7 +7,7 @@
 
 export const sidebarConfig = {
   // Activar/desactivar el sidebar globalmente
-  enabled: false,
+  enabled: true,
   
   // Comportamiento del sidebar
   expandOnHover: true,


### PR DESCRIPTION
- Habilitar sidebar globalmente (sidebar.config enabled: true)
- Agregar animaciones con motion/react en brand, menú y panel móvil
- Rediseñar header mobile con branding pill y botón circular
- Reemplazar panel móvil por overlay animado con cards estilizadas
- Agregar texto DERKYSAN animado en brand del sidebar desktop
- Actualizar SideBar: bordes redondeados, gradiente radial al expandir, transiciones suaves en header/menu/footer y opacidad contextual
- Agregar prop  en CustomLogo para variante compacta
- Actualizar labels de menú a estilo mono uppercase con tracking
- Corregir email de contacto y comentar item de LinkedIn temporalmente
- Ajustar footer con layout responsive (row/col) según estado expandido