### PR TITLE
feat(mobile): redesign mobile menu with fullscreen blur overlay and animated Plus icon

### DIFF
--- a/src/components/layouts/SidebarLayout.tsx
+++ b/src/components/layouts/SidebarLayout.tsx
@@ -4,14 +4,12 @@ import { AnimatePresence, motion } from "motion/react"
 import { SideBar, type SidebarMenuItem } from "../shared/SideBar"
 import { CustomLogo } from "../shared/CustomLogo"
 import {
-  ArrowUpRight,
-  Menu,
-  X,
   Mail,
   Settings,
   FileText,
   Home,
   Briefcase,
+  Plus,
 } from "lucide-react"
 import { FaLinkedinIn } from "react-icons/fa";
 import { FiGithub } from "react-icons/fi";
@@ -200,11 +198,39 @@ export const SidebarLayout: React.FC<SidebarLayoutProps> = ({
 
   return (
     <div className="flex h-screen overflow-hidden">
-      <header className="fixed inset-x-0 top-0 z-40 flex h-16 items-center justify-between border-[#F07D00]/20 px-4 backdrop-blur-xl md:hidden">
+      <header className="fixed inset-x-0 top-0 z-40 flex py-6 items-center justify-between border-[#F07D00]/20 px-4 backdrop-blur-xl md:hidden">
         <div className="flex items-center gap-3 rounded-full border-[#F07D00]/20 px-3 py-2 shadow-[0_8px_24px_rgba(0,0,0,0.18)]">
-          <div className="h-8 w-8 shrink-0 overflow-hidden">
+          <div className="h-10 shrink-0 overflow-hidden">
             <CustomLogo contained />
+            {/* <AnimatePresence initial={false}>
+              {mobileMenuOpen && (
+                <motion.span
+                  key="brand-text"
+                  initial={{ opacity: 0, width: 0, x: -10 }}
+                  animate={{ opacity: 1, width: "auto", x: 0 }}
+                  exit={{ opacity: 0, width: 0, x: -10 }}
+                  transition={SIDEBAR_BRAND_TRANSITION}
+                  className="overflow-hidden whitespace-nowrap text-sm tracking-[0.24em] font-mono"
+                >
+                  DERKYSAN
+                </motion.span>
+              )}
+            </AnimatePresence> */}
           </div>
+          <AnimatePresence initial={false}>
+            {mobileMenuOpen && (
+              <motion.span
+                key="brand-text"
+                initial={{ opacity: 0, width: 0, x: -10 }}
+                animate={{ opacity: 1, width: "auto", x: 0 }}
+                exit={{ opacity: 0, width: 0, x: -10 }}
+                transition={SIDEBAR_BRAND_TRANSITION}
+                className="overflow-hidden whitespace-nowrap text-sm tracking-[0.24em] font-mono"
+              >
+                DERKYSAN
+              </motion.span>
+            )}
+          </AnimatePresence>
           {/* <span className="text-[11px] tracking-[0.28em] text-foreground/80">DERKYSAN</span> */}
         </div>
         <button
@@ -213,151 +239,83 @@ export const SidebarLayout: React.FC<SidebarLayoutProps> = ({
           aria-label={mobileMenuOpen ? "Cerrar menú" : "Abrir menú"}
           className="inline-flex h-11 w-11 items-center justify-center rounded-full border-[#F07D00]/30 bg-background/80 text-primary shadow-[0_8px_24px_rgba(0,0,0,0.18)] transition-colors hover:bg-accent"
         >
-          {mobileMenuOpen ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
+          <motion.div
+            animate={{ rotate: mobileMenuOpen ? 45 : 0 }}
+            transition={{ duration: 0.3, ease: [0.4, 0, 0.2, 1] }}
+          >
+            <Plus className="h-5 w-5" />
+          </motion.div>
         </button>
       </header>
 
       <AnimatePresence>
         {mobileMenuOpen && (
-          <div className="fixed inset-0 z-50 md:hidden" aria-hidden={!mobileMenuOpen}>
-            <motion.button
-              type="button"
-              aria-label="Cerrar menú"
-              className="absolute inset-0 bg-black/55 backdrop-blur-sm"
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              exit={{ opacity: 0 }}
-              transition={MOBILE_PANEL_TRANSITION}
-              onClick={() => setMobileMenuOpen(false)}
-            />
-            <motion.div
-              initial={{ opacity: 0, y: 24, scale: 0.98 }}
-              animate={{ opacity: 1, y: 0, scale: 1 }}
-              exit={{ opacity: 0, y: 20, scale: 0.98 }}
-              transition={MOBILE_PANEL_TRANSITION}
-              className="absolute inset-x-3 bottom-3 top-3 overflow-hidden rounded-[28px] border border-[#F07D00]/25 bg-background/92 shadow-[0_24px_80px_rgba(0,0,0,0.45)] backdrop-blur-2xl"
+          <motion.div
+            className="fixed inset-0 z-30 flex flex-col justify-center bg-black/65 backdrop-blur-md md:hidden"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={MOBILE_PANEL_TRANSITION}
+            onClick={() => setMobileMenuOpen(false)}
+          >
+            <motion.nav
+              initial="hidden"
+              animate="show"
+              exit="hidden"
+              variants={{
+                hidden: {},
+                show: {
+                  transition: {
+                    staggerChildren: 0.08,
+                    delayChildren: 0.12,
+                  },
+                },
+              }}
+              className="flex flex-col items-center gap-10"
+              onClick={(e) => e.stopPropagation()}
             >
-              <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_right,rgba(240,125,0,0.18),transparent_34%),linear-gradient(180deg,rgba(255,255,255,0.03),transparent_18%)]" />
+              {mobileMenuItems.map((item) => {
+                const isExternalLink = !!item.href && /^(https?:\/\/|mailto:)/i.test(item.href)
 
-              <div className="relative flex h-full flex-col px-5 pb-5 pt-4">
-                <div className="flex items-start justify-between gap-4 border-b border-[#F07D00]/15 pb-4">
-                  {customBrand ? (
-                    <div className="min-w-0 flex-1 overflow-hidden">
-                      {customBrand}
-                    </div>
-                  ) : (
-                    <a href="/" className="flex min-w-0 items-center gap-3">
-                      <div className="flex h-12 w-12 items-center justify-center overflow-hidden">
-                        <CustomLogo active contained />
-                      </div>
-                      <div className="min-w-0">
-                        <p className="text-[11px] uppercase tracking-[0.28em] text-foreground/60">
-                          Menu
-                        </p>
-                        <p className="truncate text-sm tracking-[0.22em] text-foreground">
-                          DERKYSAN
-                        </p>
-                      </div>
-                    </a>
-                  )}
-
-                  <button
-                    type="button"
-                    onClick={() => setMobileMenuOpen(false)}
-                    aria-label="Cerrar menú"
-                    className="inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-full border border-[#F07D00]/20 bg-background/80 text-primary transition-colors hover:bg-accent"
-                  >
-                    <X className="h-5 w-5" />
-                  </button>
-                </div>
-
-                <div className="flex-1 overflow-y-auto py-6">
+                const content = (
                   <motion.div
-                    initial="hidden"
-                    animate="show"
-                    exit="hidden"
                     variants={{
-                      hidden: {},
-                      show: {
-                        transition: {
-                          staggerChildren: 0.05,
-                          delayChildren: 0.04,
-                        },
-                      },
+                      hidden: { opacity: 0, x: -16 },
+                      show: { opacity: 1, x: 0 },
                     }}
-                    className="space-y-3"
+                    transition={{ duration: 0.3, ease: [0.4, 0, 0.2, 1] }}
+                    className="flex items-center"
                   >
-                    {mobileMenuItems.map((item) => {
-                      const isExternalLink = !!item.href && /^(https?:\/\/|mailto:)/i.test(item.href)
-                      const itemClasses =
-                        "group flex w-full items-center gap-4 rounded-2xl border border-white/10 bg-white/[0.03] px-4 py-4 text-left transition-all duration-300 ease-in-out hover:border-[#F07D00]/30 hover:bg-white/[0.06]"
-
-                      const content = (
-                        <>
-                          <span className="flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl border border-[#F07D00]/20 bg-[#F07D00]/10 text-[#F7A23B]">
-                            {item.icon}
-                          </span>
-                          <span className="min-w-0 flex-1">
-                            <span className="block truncate text-sm text-foreground">
-                              {item.label}
-                            </span>
-                            <span className="block truncate pt-1 text-[11px] uppercase tracking-[0.18em] text-foreground/45">
-                              {item.href?.replace(/^mailto:/, "") || "Abrir"}
-                            </span>
-                          </span>
-                          <ArrowUpRight className="h-4 w-4 shrink-0 text-foreground/35 transition-transform duration-300 ease-in-out group-hover:-translate-y-0.5 group-hover:translate-x-0.5 group-hover:text-[#F7A23B]" />
-                        </>
-                      )
-
-                      return (
-                        <motion.div
-                          key={item.id}
-                          variants={{
-                            hidden: { opacity: 0, y: 14 },
-                            show: { opacity: 1, y: 0 },
-                          }}
-                          transition={MOBILE_PANEL_TRANSITION}
-                        >
-                          {item.href ? (
-                            <a
-                              href={item.href}
-                              target={isExternalLink ? "_blank" : undefined}
-                              rel={isExternalLink ? "noopener noreferrer" : undefined}
-                              onClick={() => handleMobileItemClick(item)}
-                              className={itemClasses}
-                            >
-                              {content}
-                            </a>
-                          ) : (
-                            <button
-                              type="button"
-                              onClick={() => handleMobileItemClick(item)}
-                              className={itemClasses}
-                            >
-                              {content}
-                            </button>
-                          )}
-                        </motion.div>
-                      )
-                    })}
+                    <span className="whitespace-nowrap font-mono text-xs uppercase tracking-[0.24em] text-gray-300">
+                      {item.label}
+                    </span>
                   </motion.div>
-                </div>
+                )
 
-                <div className="border-t border-[#F07D00]/15 pt-4">
-                  {customFooter ? (
-                    <div className="overflow-hidden rounded-2xl border border-white/10 bg-white/[0.03] p-4">
-                      {customFooter}
-                    </div>
-                  ) : (
-                    <div className="flex items-center justify-between gap-3 rounded-2xl border border-white/10 bg-white/[0.03] px-4 py-3 text-[11px] uppercase tracking-[0.16em] text-foreground/55">
-                      <span>© 2026</span>
-                      <span className="text-[#F7A23B]">Software Developer</span>
-                    </div>
-                  )}
-                </div>
-              </div>
-            </motion.div>
-          </div>
+                return item.href ? (
+                  <a
+                    key={item.id}
+                    href={item.href}
+                    target={isExternalLink ? "_blank" : undefined}
+                    rel={isExternalLink ? "noopener noreferrer" : undefined}
+                    onClick={() => handleMobileItemClick(item)}
+                    className="transition-colors duration-200 hover:text-white"
+                  >
+                    {content}
+                  </a>
+                ) : (
+                  <button
+                    key={item.id}
+                    type="button"
+                    onClick={() => handleMobileItemClick(item)}
+                    className="transition-colors duration-200 hover:text-white"
+                  >
+                    {content}
+                  </button>
+                )
+              })}
+            </motion.nav>
+          </motion.div>
         )}
       </AnimatePresence>
 

--- a/src/components/shared/CustomHeroTitle.tsx
+++ b/src/components/shared/CustomHeroTitle.tsx
@@ -21,7 +21,7 @@ export const CustomHeroTitle = () => {
   const isDark = activeTheme === "dark";
 
   return (
-    <h1 className="tracking-widest text-3xl uppercase mb-3 bg-background flex-wrap">
+    <h1 className="tracking-wider text-3xl uppercase mb-3 bg-background flex-wrap">
       Hola, Soy <span className={isDark ? `text-gradient-light` : "text-black"}>Derky Sánchez</span>
     </h1>
   );

--- a/src/components/shared/CustomLogo.tsx
+++ b/src/components/shared/CustomLogo.tsx
@@ -31,8 +31,8 @@ export const CustomLogo: React.FC<CustomLogoProps> = ({
   const restingScale = contained ? 1 : 1;
   const activeScale = contained ? 1 : 1;
   const hoverScale = contained ? 1 : 1.1;
-  const logoWidth = contained ? 24 : 40;
-  const logoHeight = contained ? 28 : 45;
+  const logoWidth = contained ? 30 : 40;
+  const logoHeight = contained ? 34 : 45;
 
   return (
     <motion.div


### PR DESCRIPTION
- Replace card-based mobile menu with centered fullscreen blur curtain
- Use single Plus icon that rotates 45° to become X when menu is open
- Show brand text "DERKYSAN" with animated reveal on menu open
- Display menu items centered, text-only (no icons), with staggered slide-in animation
- Enlarge mobile logo from 24×28 to 30×34px
- Update hero title tracking from widest to wider